### PR TITLE
fix(.github): missing cargo registry token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,8 @@ jobs:
           toolchain: stable
           override: true
       - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Why

Because to upload to the Rust Crato.io registry, the CI needs credentials.
