### PR TITLE
fix(cli): license config in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["command-line-utilities"]
 version = "0.0.3"
 readme = "README.md"
 repository = "https://github.com/KeisukeYamashita/commitlint-rs"
-license-file = "Apache-2.0 or MIT"
+license = "Apache-2.0 or MIT"
 edition = "2021"
 exclude = ["/web"]
 


### PR DESCRIPTION
# Why

Fix `license` as `license-file` has to specify a existing file and it's not what I wanted to specify.