### PR TITLE
fix(web): base for GitHub Pages

### DIFF
--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -3,7 +3,8 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://keisukeyamashita.github.io/commitlint-rs',
+  site: 'https://keisukeyamashita.github.io',
+  base: '/commitlint-rs',
   integrations: [
     starlight({
       title: 'Commitlint',


### PR DESCRIPTION
# Why

Base is used for loading the static files. 
On GitHub pages, the path `/<REPOSITORY_NAME>` is needed.
