### PR TITLE
fix(cli): correct double license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["command-line-utilities"]
 version = "0.0.3"
 readme = "README.md"
 repository = "https://github.com/KeisukeYamashita/commitlint-rs"
-license = "Apache-2.0 or MIT"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 exclude = ["/web"]
 


### PR DESCRIPTION
# Why

Because it's in malformed SPDX.

## Ref

I have followed the rust-lang's configuration.

https://github.com/rust-lang/cargo/blob/0c14026aa84ee2ec4c67460c0a18abc8519ca6b2/Cargo.toml#L102
