### PR TITLE
feat(other): add docker to Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,12 @@ updates:
     schedule:
       interval: "daily"
 
+  # Maintain dependencies for Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
     directory: "/web"


### PR DESCRIPTION
# Why

Resolves: #41 

To manage the Docker dependency.
We want to make everything secure, up to date 🚀 
