### PR TITLE
feat(.github): add `docker` to `needs` for `publish` job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - crate
+      - docker
       - web
     steps:
       - uses: ncipollo/release-action@v1


### PR DESCRIPTION
# Why

Because the release publishing should wait for Docker release.
