### PR TITLE
feat(.github): update pr title type

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,18 +2,27 @@ version: 2
 updates:
   # Maintain dependencies for Rust (Cargo)
   - package-ecosystem: "cargo"
+    commit-message:
+      include: scope
+      prefix: bump
     directory: "/"
     schedule:
       interval: "daily"
 
   # Maintain dependencies for Docker
   - package-ecosystem: "docker"
+    commit-message:
+      include: scope
+      prefix: bump
     directory: "/"
     schedule:
       interval: "daily"
 
   # Maintain dependencies for npm
   - package-ecosystem: "npm"
+    commit-message:
+      include: scope
+      prefix: bump
     directory: "/web"
     schedule:
       interval: "daily"


### PR DESCRIPTION
# Why

Update PR title's `type` because I would like to use `bump` instead of the default `build`.
