### PR TITLE
feat(.github): add clippy lint reviewdog action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,6 +39,10 @@ jobs:
         with:
           command: clippy
 
+      - uses: sksat/action-clippy@v0.2.1
+        with:
+          reporter: github-pr-review
+
   markdown:
     name: markdown
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Why

To make review easy!
I forgot to run the Clippy on PR run so I have introduced the `sksat/action-clippy@main` GItHub Action action.