### PR TITLE
feat(cli): add support for --edit and pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: commitlint
+  name: Assert Conventional Commit Messages
+  description: 'Asserts that Conventional Commits have been used for all commit messages according to the rules for this repo.'
+  entry: commitlint --edit
+  language: rust
+  stages: [prepare-commit-msg]
+  pass_filenames: false
+  require_serial: true
+  verbose: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "commitlint-rs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "futures",

--- a/src/args.rs
+++ b/src/args.rs
@@ -55,7 +55,7 @@ impl Args {
         // `pre-commit`, stdin exists, so this needs to come first.
         if self.edit {
             let msg = std::fs::read_to_string("./.git/COMMIT_EDITMSG")
-                .expect("Failed to read './.git/COMMIT_EDITMSG");
+                .expect("Failed to read './.git/COMMIT_EDITMSG'");
             return Ok(vec![Message::new(msg)]);
         }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -51,6 +51,15 @@ impl Args {
 
     /// Read commit messages from stdin.
     pub fn read(&self) -> Result<Vec<Message>, Error> {
+        // Check first whether or not the --edit option was supplied. When running from tooling such as
+        // `pre-commit`, stdin exists, so this needs to come first.
+        if self.edit {
+            let msg = std::fs::read_to_string("./.git/COMMIT_EDITMSG")
+                .expect("Failed to read './.git/COMMIT_EDITMSG");
+            return Ok(vec![Message::new(msg)]);
+        }
+
+        // Otherwise, check for stdin and use the incoming text buffer from there if so.
         if self.has_stdin() {
             let mut buffer = String::new();
             stdin()
@@ -59,11 +68,13 @@ impl Args {
             return Ok(vec![Message::new(buffer)]);
         }
 
+        // And if none of the above, we're expecting to be reading directly from Git...
         let config = ReadCommitMessageOptions {
             from: self.from.clone(),
             path: self.cwd.clone(),
             to: self.to.clone(),
         };
+
         let messages = git::read(config)
             .iter()
             .map(|s| Message::new(s.to_string()))


### PR DESCRIPTION
I wanted to use this together with [pre-commit](https://pre-commit.com/) but noticed that support for `--edit` was missing, so I went ahead and added at least the default using `./.git/COMMIT_EDITMSG`.

Also added a `.pre-commit-hooks.yaml` so that the repo can be used together with `pre-commit`.  Nothing fancy here...

And, thanks for this! Much better than the node commitlint solution for rust projects :)
