### PR TITLE
fix(web): broken `Read the rules` button

### DIFF
--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -12,7 +12,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: Read the rules
-      link: /commitlint-rs/guides/rules/
+      link: /commitlint-rs/rules/body-empty
       icon: external
 ---
 


### PR DESCRIPTION
# Why

Fixes #175 
We are using the [Starlight](https://starlight.astro.build/) so we can't have `index.astro`. 
Therefore, I had to navigate to the first rule.