### PR TITLE
fix(web): install target cargo name `commitlint-rs` from `commitlint`

### DIFF
--- a/web/src/content/docs/setup/install.md
+++ b/web/src/content/docs/setup/install.md
@@ -8,7 +8,7 @@ description: Guide how to install commitlint to your project
 Commitlint is written in Rust so you can install it using `cargo` CLI:
 
 ```console
-cargo install commitlint
+cargo install commitlint-rs
 ```
 
 After that, you will be able to run the `commitlint` command.


### PR DESCRIPTION
# Why

Fixes: https://github.com/KeisukeYamashita/commitlint-rs/issues/206

`commitlint` is totally a different cargo package. The correct one is:

https://github.com/KeisukeYamashita/commitlint-rs/blob/4bc1f521f514b58902ea18ada3157ecc182eaa8a/Cargo.toml#L2