### PR TITLE
fix(cli): loading configuration files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,7 @@ pub fn find_config_file(path: PathBuf) -> Option<PathBuf> {
         if path.exists() {
             return Some(path);
         }
+        path.pop();
     }
 
     None


### PR DESCRIPTION
The logic for searching for the config file was incorrectly pushing paths to the PathBuf without popping, causing it to look for the wrong file paths.

# Why

I found that it was not detecting the yaml configuration files. I investigated and found this.

