### PR TITLE
feat(web): add how to debug page

### DIFF
--- a/web/src/content/docs/setup/debug.md
+++ b/web/src/content/docs/setup/debug.md
@@ -1,0 +1,12 @@
+---
+title: Motivation
+description: Debug your configurations
+---
+
+You maybe wondering how you can debug your configurations. This is a common question and we have a few options for you to consider.
+
+Debug your configuration using stdin and below:
+
+```console
+echo "feat(other): debug" | commitlint
+```


### PR DESCRIPTION
# Why

To let users easy to debug their configuration before putting this tool into product and make them confident to make updates.