### PR TITLE
chore(cli): config print without `to_string`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ async fn main() {
     };
 
     if args.print_config {
-        println!("{}", config.to_string());
+        println!("{}", config);
     }
 
     let messages = match args.read() {


### PR DESCRIPTION
# Why

No need to use `to_string` to print the config.