### PR TITLE
fix(cli): clippy lint for length comparision

### DIFF
--- a/src/rule/scope.rs
+++ b/src/rule/scope.rs
@@ -23,7 +23,7 @@ impl Rule for Scope {
     const LEVEL: Level = Level::Error;
 
     fn message(&self, message: &Message) -> String {
-        if self.options.len() == 0 {
+        if self.options.is_empty() {
             return "scopes are not allowed".to_string();
         }
 

--- a/src/rule/type.rs
+++ b/src/rule/type.rs
@@ -22,7 +22,7 @@ impl Rule for Type {
     const NAME: &'static str = "type";
     const LEVEL: Level = Level::Error;
     fn message(&self, message: &Message) -> String {
-        if self.options.len() == 0 {
+        if self.options.is_empty() {
             return "types are not allowed".to_string();
         }
 


### PR DESCRIPTION
# Why

Because `len` should not compare to `0` 🙏 
