### PR TITLE
fix(cli): empty string check for description

### DIFF
--- a/src/rule/description_empty.rs
+++ b/src/rule/description_empty.rs
@@ -23,14 +23,17 @@ impl Rule for DescriptionEmpty {
     }
 
     fn validate(&self, message: &Message) -> Option<Violation> {
-        if message.description.is_none() {
-            return Some(Violation {
+        match message.description {
+            None => Some(Violation {
                 level: self.level.unwrap_or(Self::LEVEL),
                 message: self.message(message),
-            });
+            }),
+            Some(ref desc) if desc.is_empty() => Some(Violation {
+                level: self.level.unwrap_or(Self::LEVEL),
+                message: self.message(message),
+            }),
+            _ => None,
         }
-
-        None
     }
 }
 
@@ -69,6 +72,28 @@ mod tests {
         let message = Message {
             body: None,
             description: None,
+            footers: None,
+            r#type: Some("feat".to_string()),
+            raw: "(scope):".to_string(),
+            scope: Some("scope".to_string()),
+            subject: None,
+        };
+
+        let violation = rule.validate(&message);
+        assert!(violation.is_some());
+        assert_eq!(violation.clone().unwrap().level, Level::Error);
+        assert_eq!(
+            violation.unwrap().message,
+            "description is empty or missing space in the beginning".to_string()
+        );
+    }
+
+    #[test]
+    fn test_blank_description() {
+        let rule = DescriptionEmpty::default();
+        let message = Message {
+            body: None,
+            description: Some("".to_string()),
             footers: None,
             r#type: Some("feat".to_string()),
             raw: "(scope):".to_string(),


### PR DESCRIPTION
# Why

Fixes: https://github.com/KeisukeYamashita/commitlint-rs/issues/257

Currently, the rule is only checking if the description is `None` or not.
But the empty string `"` must also be checked.