### PR TITLE
fix(cli): unexpected error on `""` (empty) scope or type input

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -48,10 +48,10 @@ impl Message {
         let (r#type, scope, description) = parse_subject(&subject);
         Self {
             body,
-            description: Some(description),
+            description,
             footers,
             raw,
-            r#type: Some(r#type),
+            r#type,
             scope,
             subject: Some(subject),
         }

--- a/src/rule/scope.rs
+++ b/src/rule/scope.rs
@@ -35,10 +35,21 @@ impl Rule for Scope {
     }
 
     fn validate(&self, message: &Message) -> Option<Violation> {
-        if let Some(scope) = &message.scope {
-            if self.options.contains(scope) {
+        match &message.scope {
+            None => {
+                if self.options.is_empty() {
+                    return None;
+                }
+            }
+            Some(scope) if scope.is_empty() => {
+                if self.options.is_empty() {
+                    return None;
+                }
+            }
+            Some(scope) if self.options.contains(scope) => {
                 return None;
             }
+            _ => {}
         }
 
         Some(Violation {
@@ -62,92 +73,159 @@ impl Default for Scope {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_empty_scope() {
-        let mut rule = Scope::default();
-        rule.options = vec!["api".to_string(), "web".to_string()];
+    mod empty_options {
+        use super::*;
 
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: None,
-            raw: "".to_string(),
-            scope: None,
-            subject: None,
-        };
+        #[test]
+        fn test_empty_scope() {
+            let rule = Scope::default();
 
-        let violation = rule.validate(&message);
-        assert!(violation.is_some());
-        assert_eq!(violation.clone().unwrap().level, Level::Error);
-        assert_eq!(
-            violation.unwrap().message,
-            "scope  is not allowed. Only [\"api\", \"web\"] are allowed"
-        );
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: None,
+                raw: "".to_string(),
+                scope: Some("".to_string()),
+                subject: None,
+            };
+
+            let violation = rule.validate(&message);
+            assert!(violation.is_none());
+        }
+
+        #[test]
+        fn test_none_scope() {
+            let rule = Scope::default();
+
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: None,
+                raw: "".to_string(),
+                scope: None,
+                subject: None,
+            };
+
+            let violation = rule.validate(&message);
+            assert!(violation.is_none());
+        }
+
+        #[test]
+        fn test_scope() {
+            let rule = Scope::default();
+
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: Some("feat".to_string()),
+                raw: "feat(web): broadcast $destroy event on scope destruction".to_string(),
+                scope: Some("web".to_string()),
+                subject: None,
+            };
+
+            let violation = rule.validate(&message);
+            assert!(violation.is_some());
+            assert_eq!(violation.clone().unwrap().level, Level::Error);
+            assert_eq!(
+                violation.unwrap().message,
+                "scopes are not allowed".to_string()
+            );
+        }
     }
 
-    #[test]
-    fn test_valid_scope() {
-        let mut rule = Scope::default();
-        rule.options = vec!["api".to_string(), "web".to_string()];
+    mod scopes {
+        use super::*;
+        #[test]
+        fn test_empty_scope() {
+            let mut rule = Scope::default();
+            rule.options = vec!["api".to_string(), "web".to_string()];
 
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: Some("feat".to_string()),
-            raw: "feat(web): broadcast $destroy event on scope destruction".to_string(),
-            scope: Some("web".to_string()),
-            subject: None,
-        };
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: None,
+                raw: "".to_string(),
+                scope: Some("".to_string()),
+                subject: None,
+            };
 
-        assert!(rule.validate(&message).is_none());
-    }
+            let violation = rule.validate(&message);
+            assert!(violation.is_some());
+            assert_eq!(violation.clone().unwrap().level, Level::Error);
+            assert_eq!(
+                violation.unwrap().message,
+                "scope  is not allowed. Only [\"api\", \"web\"] are allowed"
+            );
+        }
 
-    #[test]
-    fn test_invalid_scope() {
-        let mut rule = Scope::default();
-        rule.options = vec!["api".to_string(), "web".to_string()];
+        #[test]
+        fn test_none_scope() {
+            let mut rule = Scope::default();
+            rule.options = vec!["api".to_string(), "web".to_string()];
 
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: Some("feat".to_string()),
-            raw: "feat(invalid): broadcast $destroy event on scope destruction".to_string(),
-            scope: Some("invalid".to_string()),
-            subject: None,
-        };
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: None,
+                raw: "".to_string(),
+                scope: None,
+                subject: None,
+            };
 
-        let violation = rule.validate(&message);
-        assert!(violation.is_some());
-        assert_eq!(violation.clone().unwrap().level, Level::Error);
-        assert_eq!(
-            violation.unwrap().message,
-            "scope invalid is not allowed. Only [\"api\", \"web\"] are allowed".to_string()
-        );
-    }
+            let violation = rule.validate(&message);
+            assert!(violation.is_some());
+            assert_eq!(violation.clone().unwrap().level, Level::Error);
+            assert_eq!(
+                violation.unwrap().message,
+                "scope  is not allowed. Only [\"api\", \"web\"] are allowed".to_string()
+            );
+        }
 
-    #[test]
-    fn test_no_options() {
-        let rule = Scope::default();
+        #[test]
+        fn test_valid_scope() {
+            let mut rule = Scope::default();
+            rule.options = vec!["api".to_string(), "web".to_string()];
 
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: Some("feat".to_string()),
-            raw: "feat(invalid): broadcast $destroy event on scope destruction".to_string(),
-            scope: Some("invalid".to_string()),
-            subject: None,
-        };
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: Some("feat".to_string()),
+                raw: "feat(web): broadcast $destroy event on scope destruction".to_string(),
+                scope: Some("web".to_string()),
+                subject: None,
+            };
 
-        let violation = rule.validate(&message);
-        assert!(violation.is_some());
-        assert_eq!(violation.clone().unwrap().level, Level::Error);
-        assert_eq!(
-            violation.unwrap().message,
-            "scopes are not allowed".to_string()
-        );
+            assert!(rule.validate(&message).is_none());
+        }
+
+        #[test]
+        fn test_invalid_scope() {
+            let mut rule = Scope::default();
+            rule.options = vec!["api".to_string(), "web".to_string()];
+
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: Some("feat".to_string()),
+                raw: "feat(invalid): broadcast $destroy event on scope destruction".to_string(),
+                scope: Some("invalid".to_string()),
+                subject: None,
+            };
+
+            let violation = rule.validate(&message);
+            assert!(violation.is_some());
+            assert_eq!(violation.clone().unwrap().level, Level::Error);
+            assert_eq!(
+                violation.unwrap().message,
+                "scope invalid is not allowed. Only [\"api\", \"web\"] are allowed".to_string()
+            );
+        }
     }
 }

--- a/src/rule/type.rs
+++ b/src/rule/type.rs
@@ -34,10 +34,21 @@ impl Rule for Type {
     }
 
     fn validate(&self, message: &Message) -> Option<Violation> {
-        if let Some(t) = &message.r#type {
-            if self.options.contains(t) {
+        match &message.r#type {
+            None => {
+                if self.options.is_empty() {
+                    return None;
+                }
+            }
+            Some(r#type) if r#type.is_empty() => {
+                if self.options.is_empty() {
+                    return None;
+                }
+            }
+            Some(r#type) if self.options.contains(r#type) => {
                 return None;
             }
+            _ => {}
         }
 
         Some(Violation {
@@ -61,133 +72,159 @@ impl Default for Type {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_empty_type() {
-        let mut rule = Type::default();
-        rule.options = vec!["doc".to_string(), "feat".to_string()];
+    mod empty_options {
+        use super::*;
 
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: None,
-            raw: "".to_string(),
-            scope: None,
-            subject: None,
-        };
-        assert_eq!(rule.validate(&message).unwrap().level, Level::Error);
-        assert_eq!(
-            rule.validate(&message).unwrap().message,
-            "type  is not allowed. Only [\"doc\", \"feat\"] are allowed".to_string()
-        );
+        #[test]
+        fn test_empty_type() {
+            let rule = Type::default();
+
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: None,
+                raw: "".to_string(),
+                scope: Some("".to_string()),
+                subject: None,
+            };
+
+            let violation = rule.validate(&message);
+            assert!(violation.is_none());
+        }
+
+        #[test]
+        fn test_none_type() {
+            let rule = Type::default();
+
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: None,
+                raw: "".to_string(),
+                scope: None,
+                subject: None,
+            };
+
+            let violation = rule.validate(&message);
+            assert!(violation.is_none());
+        }
+
+        #[test]
+        fn test_type() {
+            let rule = Type::default();
+
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: Some("feat".to_string()),
+                raw: "feat(web): broadcast $destroy event on scope destruction".to_string(),
+                scope: Some("web".to_string()),
+                subject: None,
+            };
+
+            let violation = rule.validate(&message);
+            assert!(violation.is_some());
+            assert_eq!(violation.clone().unwrap().level, Level::Error);
+            assert_eq!(
+                violation.unwrap().message,
+                "types are not allowed".to_string()
+            );
+        }
     }
 
-    #[test]
-    fn test_invalid_type() {
-        let mut rule = Type::default();
-        rule.options = vec!["doc".to_string(), "feat".to_string()];
+    mod scopes {
+        use super::*;
+        #[test]
+        fn test_empty_type() {
+            let mut rule = Type::default();
+            rule.options = vec!["feat".to_string(), "chore".to_string()];
 
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: Some("invalid".to_string()),
-            raw: "invalid(scope): broadcast $destroy event on scope destruction".to_string(),
-            scope: None,
-            subject: None,
-        };
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: None,
+                raw: "".to_string(),
+                scope: Some("".to_string()),
+                subject: None,
+            };
 
-        let violation = rule.validate(&message);
-        assert!(violation.is_some());
-        assert_eq!(violation.clone().unwrap().level, Level::Error);
-        assert_eq!(
-            violation.unwrap().message,
-            "type invalid is not allowed. Only [\"doc\", \"feat\"] are allowed".to_string()
-        );
-    }
+            let violation = rule.validate(&message);
+            assert!(violation.is_some());
+            assert_eq!(violation.clone().unwrap().level, Level::Error);
+            assert_eq!(
+                violation.unwrap().message,
+                "type  is not allowed. Only [\"feat\", \"chore\"] are allowed"
+            );
+        }
 
-    #[test]
-    fn test_no_options() {
-        let rule = Type::default();
+        #[test]
+        fn test_none_type() {
+            let mut rule = Type::default();
+            rule.options = vec!["feat".to_string(), "chore".to_string()];
 
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: Some("invalid".to_string()),
-            raw: "invalid(scope): broadcast $destroy event on scope destruction".to_string(),
-            scope: None,
-            subject: None,
-        };
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: None,
+                raw: "".to_string(),
+                scope: None,
+                subject: None,
+            };
 
-        let violation = rule.validate(&message);
-        assert!(violation.is_some());
-        assert_eq!(violation.clone().unwrap().level, Level::Error);
-        assert_eq!(
-            violation.unwrap().message,
-            "types are not allowed".to_string()
-        );
-    }
+            let violation = rule.validate(&message);
+            assert!(violation.is_some());
+            assert_eq!(violation.clone().unwrap().level, Level::Error);
+            assert_eq!(
+                violation.unwrap().message,
+                "type  is not allowed. Only [\"feat\", \"chore\"] are allowed".to_string()
+            );
+        }
 
-    #[test]
-    fn test_no_options_with_empty_type() {
-        let rule = Type::default();
+        #[test]
+        fn test_valid_type() {
+            let mut rule = Type::default();
+            rule.options = vec!["feat".to_string(), "chore".to_string()];
 
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: None,
-            raw: "(scope): broadcast $destroy event on scope destruction".to_string(),
-            scope: None,
-            subject: None,
-        };
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: Some("feat".to_string()),
+                raw: "feat(web): broadcast $destroy event on scope destruction".to_string(),
+                scope: Some("web".to_string()),
+                subject: None,
+            };
 
-        let violation = rule.validate(&message);
-        assert!(violation.is_some());
-        assert_eq!(violation.clone().unwrap().level, Level::Error);
-        assert_eq!(
-            violation.unwrap().message,
-            "types are not allowed".to_string()
-        );
-    }
+            assert!(rule.validate(&message).is_none());
+        }
 
-    #[test]
-    fn test_missing_type() {
-        let rule = Type::default();
-        let input = "test".to_string();
+        #[test]
+        fn test_invalid_type() {
+            let mut rule = Type::default();
+            rule.options = vec!["feat".to_string(), "chore".to_string()];
 
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: None,
-            raw: input.clone(),
-            scope: None,
-            subject: None,
-        };
-        assert_eq!(rule.validate(&message).unwrap().level, Level::Error);
-        assert_eq!(
-            rule.validate(&message).unwrap().message,
-            "types are not allowed".to_string()
-        );
-    }
+            let message = Message {
+                body: None,
+                description: None,
+                footers: None,
+                r#type: Some("invalid".to_string()),
+                raw: "invalid(web): broadcast $destroy event on scope destruction".to_string(),
+                scope: Some("web".to_string()),
+                subject: None,
+            };
 
-    #[test]
-    fn test_valid_type() {
-        let mut rule = Type::default();
-        rule.options = vec!["doc".to_string(), "feat".to_string()];
-
-        let message = Message {
-            body: None,
-            description: None,
-            footers: None,
-            r#type: Some("feat".to_string()),
-            raw: "feat(scope): broadcast $destroy event on scope destruction".to_string(),
-            scope: None,
-            subject: None,
-        };
-
-        assert!(rule.validate(&message).is_none());
+            let violation = rule.validate(&message);
+            assert!(violation.is_some());
+            assert_eq!(violation.clone().unwrap().level, Level::Error);
+            assert_eq!(
+                violation.unwrap().message,
+                "type invalid is not allowed. Only [\"feat\", \"chore\"] are allowed".to_string()
+            );
+        }
     }
 }


### PR DESCRIPTION
# Why

Because when the scope or type was `""`, it was not working as expected.
