### PR TITLE
doc(web): typo fix `warn` -> `warning`

### DIFF
--- a/web/src/content/docs/config/configuration.md
+++ b/web/src/content/docs/config/configuration.md
@@ -52,7 +52,7 @@ You can use the `--print-config` flag to print the configuration that will be us
 $ commitlint --print-config
 rules:
   description-empty: # Description must not be empty
-    level: warn
+    level: warning
   subject-empty: # Subject line must not be empty
     level: error
   type-empty: # Type must not be empty


### PR DESCRIPTION
This fixes case of 

```console
Failed to load config: Failed to parse configuration file: RULE: unknown variant `warn`, expected one of `error`, `ignore`, `warning
```

# Why

<!-- Please write why you are adding it -->
<!-- Attache GitHub issues if exist -->
