### PR TITLE
docs(configuration): typo fix warn to warning

### DIFF
--- a/web/src/content/docs/config/default.md
+++ b/web/src/content/docs/config/default.md
@@ -14,7 +14,7 @@ You can also check the default values on the page of each rule.
 ```yaml
 rules:
   description-empty: # Description must not be empty
-    level: warn
+    level: warning
   scope-empty: # Scope must not be empty
     level: error
   subject-empty: # Subject line should exist


### PR DESCRIPTION
# Why

This fixes case of 

```console
Failed to load config: Failed to parse configuration file: rules.scope-max-length.level: unknown variant `warn`, expected one of `error`, `ignore`, `warning
```