### PR TITLE
bump(.github): withastro to `v2`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,8 +137,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
-      - uses: withastro/action@v1
+      - uses: withastro/action@v2
         with:
           path: ./web
       - id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Why

To maintain 💅 

Note that `v2` requires to use the `v4` of `actions/deploy-pages` GitHub Actions.
