### PR TITLE
doc(other): add Fosso license scan badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,14 @@ Documents are available [here](https://keisukeyamashita.github.io/commitlint-rs)
 [![](https://img.shields.io/badge/Docker-Supported-%232496ED?logo=docker)](https://hub.docker.com/repository/docker/1915keke/commitlint)
 [![](https://img.shields.io/badge/Dependency-Dependabot-%230361cd?logo=dependabot)](https://github.com/KeisukeYamashita/commitlint-rs)
 [![](https://img.shields.io/badge/Security-Snyk-%2321204b?logo=snyk)](https://github.com/KeisukeYamashita/commitlint-rs)
+[![](https://app.fossa.com/api/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs?ref=badge_shield)
 
 </br>
 
 ## License
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs?ref=badge_shield)
-
 
 Commitlint source code is licensed either [MIT](LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE).
 
 <a  href="https://www.flaticon.com/free-icons/chinese-checkers" style="font-size: 12px;font-style: italic;"> Chinese-checkers icons created by Freepik - Flaticon</a>
 
 </div>
-
-
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,14 @@ Documents are available [here](https://keisukeyamashita.github.io/commitlint-rs)
 </br>
 
 ## License
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs?ref=badge_shield)
+
 
 Commitlint source code is licensed either [MIT](LICENSE-MIT) or [Apache-2.0](./LICENSE-APACHE).
 
 <a  href="https://www.flaticon.com/free-icons/chinese-checkers" style="font-size: 12px;font-style: italic;"> Chinese-checkers icons created by Freepik - Flaticon</a>
 
 </div>
+
+
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2FKeisukeYamashita%2Fcommitlint-rs?ref=badge_large)


### PR DESCRIPTION
## Why

To show that this project checks licenses and we don't violate any IPs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a FOSSA shield badge to the README file for improved visibility of license compliance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->