### PR TITLE
fix(cli): clippy errors in tests

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -23,8 +23,6 @@ pub struct Message {
 
     /// Description part of the commit message.
     pub description: Option<String>,
-
-    #[allow(dead_code)]
     /// Footers part of the commit message.
     pub footers: Option<HashMap<String, String>>,
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -24,9 +24,11 @@ pub struct Message {
     /// Description part of the commit message.
     pub description: Option<String>,
 
+    #[allow(dead_code)]
     /// Footers part of the commit message.
     pub footers: Option<HashMap<String, String>>,
 
+    #[allow(dead_code)]
     /// Raw commit message (or any input from stdin) including the body and footers.
     pub raw: String,
 

--- a/src/rule/description_format.rs
+++ b/src/rule/description_format.rs
@@ -78,8 +78,10 @@ mod tests {
 
     #[test]
     fn test_invalid_description_format() {
-        let mut rule = DescriptionFormat::default();
-        rule.format = Some(r"^[a-z].*".to_string());
+        let rule = DescriptionFormat {
+            format: Some(r"^[a-z].*".to_string()),
+            ..Default::default()
+        };
 
         let message = Message {
             body: None,
@@ -96,8 +98,10 @@ mod tests {
 
     #[test]
     fn test_valid_description_format() {
-        let mut rule = DescriptionFormat::default();
-        rule.format = Some(r"^[a-z].*".to_string());
+        let rule = DescriptionFormat {
+            format: Some(r"^[a-z].*".to_string()),
+            ..Default::default()
+        };
 
         let message = Message {
             body: None,
@@ -120,8 +124,10 @@ mod tests {
 
     #[test]
     fn test_invalid_regex() {
-        let mut rule = DescriptionFormat::default();
-        rule.format = Some(r"(".to_string());
+        let rule = DescriptionFormat {
+            format: Some(r"(".to_string()),
+            ..Default::default()
+        };
 
         let message = Message {
             body: None,

--- a/src/rule/scope.rs
+++ b/src/rule/scope.rs
@@ -140,8 +140,10 @@ mod tests {
         use super::*;
         #[test]
         fn test_empty_scope() {
-            let mut rule = Scope::default();
-            rule.options = vec!["api".to_string(), "web".to_string()];
+            let rule = Scope {
+                options: vec!["api".to_string(), "web".to_string()],
+                ..Default::default()
+            };
 
             let message = Message {
                 body: None,
@@ -164,8 +166,10 @@ mod tests {
 
         #[test]
         fn test_none_scope() {
-            let mut rule = Scope::default();
-            rule.options = vec!["api".to_string(), "web".to_string()];
+            let rule = Scope {
+                options: vec!["api".to_string(), "web".to_string()],
+                ..Default::default()
+            };
 
             let message = Message {
                 body: None,
@@ -188,8 +192,10 @@ mod tests {
 
         #[test]
         fn test_valid_scope() {
-            let mut rule = Scope::default();
-            rule.options = vec!["api".to_string(), "web".to_string()];
+            let rule = Scope {
+                options: vec!["api".to_string(), "web".to_string()],
+                ..Default::default()
+            };
 
             let message = Message {
                 body: None,
@@ -206,8 +212,10 @@ mod tests {
 
         #[test]
         fn test_invalid_scope() {
-            let mut rule = Scope::default();
-            rule.options = vec!["api".to_string(), "web".to_string()];
+            let rule = Scope {
+                options: vec!["api".to_string(), "web".to_string()],
+                ..Default::default()
+            };
 
             let message = Message {
                 body: None,

--- a/src/rule/scope_format.rs
+++ b/src/rule/scope_format.rs
@@ -78,8 +78,10 @@ mod tests {
 
     #[test]
     fn test_invalid_description_format() {
-        let mut rule = ScopeFormat::default();
-        rule.format = Some(r"^[a-z].*".to_string());
+        let rule = ScopeFormat {
+            format: Some(r"^[a-z].*".to_string()),
+            ..Default::default()
+        };
 
         let message = Message {
             body: None,
@@ -96,8 +98,10 @@ mod tests {
 
     #[test]
     fn test_valid_description_format() {
-        let mut rule = ScopeFormat::default();
-        rule.format = Some(r"^[a-z].*".to_string());
+        let rule = ScopeFormat {
+            format: Some(r"^[a-z].*".to_string()),
+            ..Default::default()
+        };
 
         let message = Message {
             body: None,
@@ -120,8 +124,10 @@ mod tests {
 
     #[test]
     fn test_invalid_regex() {
-        let mut rule = ScopeFormat::default();
-        rule.format = Some(r"(".to_string());
+        let rule = ScopeFormat {
+            format: Some(r"(".to_string()),
+            ..Default::default()
+        };
 
         let message = Message {
             body: None,

--- a/src/rule/type.rs
+++ b/src/rule/type.rs
@@ -139,8 +139,10 @@ mod tests {
         use super::*;
         #[test]
         fn test_empty_type() {
-            let mut rule = Type::default();
-            rule.options = vec!["feat".to_string(), "chore".to_string()];
+            let rule = Type {
+                options: vec!["feat".to_string(), "chore".to_string()],
+                ..Default::default()
+            };
 
             let message = Message {
                 body: None,
@@ -163,8 +165,10 @@ mod tests {
 
         #[test]
         fn test_none_type() {
-            let mut rule = Type::default();
-            rule.options = vec!["feat".to_string(), "chore".to_string()];
+            let rule = Type {
+                options: vec!["feat".to_string(), "chore".to_string()],
+                ..Default::default()
+            };
 
             let message = Message {
                 body: None,
@@ -187,8 +191,10 @@ mod tests {
 
         #[test]
         fn test_valid_type() {
-            let mut rule = Type::default();
-            rule.options = vec!["feat".to_string(), "chore".to_string()];
+            let rule = Type {
+                options: vec!["feat".to_string(), "chore".to_string()],
+                ..Default::default()
+            };
 
             let message = Message {
                 body: None,
@@ -205,8 +211,10 @@ mod tests {
 
         #[test]
         fn test_invalid_type() {
-            let mut rule = Type::default();
-            rule.options = vec!["feat".to_string(), "chore".to_string()];
+            let rule = Type {
+                options: vec!["feat".to_string(), "chore".to_string()],
+                ..Default::default()
+            };
 
             let message = Message {
                 body: None,

--- a/src/rule/type_format.rs
+++ b/src/rule/type_format.rs
@@ -78,8 +78,10 @@ mod tests {
 
     #[test]
     fn test_invalid_description_format() {
-        let mut rule = TypeFormat::default();
-        rule.format = Some(r"^[a-z].*".to_string());
+        let rule = TypeFormat {
+            format: Some(r"^[a-z].*".to_string()),
+            ..Default::default()
+        };
 
         let message = Message {
             body: None,
@@ -96,8 +98,10 @@ mod tests {
 
     #[test]
     fn test_valid_description_format() {
-        let mut rule = TypeFormat::default();
-        rule.format = Some(r"^[a-z].*".to_string());
+        let rule = TypeFormat {
+            format: Some(r"^[a-z].*".to_string()),
+            ..Default::default()
+        };
 
         let message = Message {
             body: None,
@@ -120,8 +124,10 @@ mod tests {
 
     #[test]
     fn test_invalid_regex() {
-        let mut rule = TypeFormat::default();
-        rule.format = Some(r"(".to_string());
+        let rule = TypeFormat {
+            format: Some(r"(".to_string()),
+            ..Default::default()
+        };
 
         let message = Message {
             body: None,


### PR DESCRIPTION
- Add dead_code flag to footer and raw of Message struct

# Why

<!-- Please write why you are adding it -->
When I run clippy with few parameters, I'm getting errors on the tests where unnecessary mut is defined.
That is not proper way to declare variables in Rust, so as best practice should be avoided even in test code.

This is the command to show the errors on main branch:
`cargo clippy  --workspace --keep-going --all-targets -- -D warnings`

<!-- Attache GitHub issues if exist -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new fields to the `Message` struct for enhanced commit message metadata.

- **Refactor**
  - Simplified initialization of various structs in test cases for improved readability and reduced code complexity.

- **Bug Fixes**
  - Ensured that the functionality of the tests remains unchanged while enhancing code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->