### PR TITLE
bump(.github): `actions-clippy` to `v1.0.0`

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,7 +49,7 @@ jobs:
         with:
           command: clippy
 
-      - uses: sksat/action-clippy@v0.2.1
+      - uses: sksat/action-clippy@v1.0.0
         with:
           reporter: github-pr-review
 


### PR DESCRIPTION
# Why

Because a major release was released and I want to keep it up to date.

## Ref

[v1.0.0, sksat/action-clippy](https://github.com/sksat/action-clippy/releases/tag/v1.0.0)
