### PR TITLE
fix(web): updated default rules url

### DIFF
--- a/web/src/content/docs/config/configuration.md
+++ b/web/src/content/docs/config/configuration.md
@@ -9,7 +9,7 @@ Commitlint can be configured in many ways. You can use the default configuration
 
 If you don't specify any configuration file and you don't have any commitlint configuration files in your environment, the CLI will use the default configurations of each rules.
 
-See the [default rules](/rules/default) page for details.
+See the [default rules](/commitlint-rs/config/default) page for details.
 
 ## Location
 


### PR DESCRIPTION
# Why

<!-- Please write why you are adding it -->
A bad redirection on the docs was bothering me
<!-- Attache GitHub issues if exist -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the path to the default rules for Commitlint in the documentation for improved clarity and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->