### PR TITLE
feat(web): add binstall instructions

### DIFF
--- a/web/src/content/docs/setup/install.md
+++ b/web/src/content/docs/setup/install.md
@@ -17,6 +17,14 @@ After that, you will be able to run the `commitlint` command.
 commitlint --help
 ```
 
+## Using Cargo Binary Install
+
+You can also use Binstall ([cargo-bins/cargo-binstal](https://github.com/cargo-bins/cargo-binstall)) to install the CLI
+
+```console
+cargo binstall commitlint-rs
+```
+
 ## Using Docker
 
 Commitlint is also available as a Docker image.


### PR DESCRIPTION
# Why

From this https://github.com/KeisukeYamashita/commitlint-rs/pull/303, this CLI is install-able with the install.
It's better to document the instructions on how to install it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new section in the documentation for `commitlint`, detailing installation via the `Binstall` tool for enhanced user convenience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->