### PR TITLE
fix(cli): typo `desc` to `scope` in scope related rules

### DIFF
--- a/src/rule/scope_format.rs
+++ b/src/rule/scope_format.rs
@@ -44,7 +44,7 @@ impl Rule for ScopeFormat {
                 None => {
                     return Some(Violation {
                         level: self.level.unwrap_or(Self::LEVEL),
-                        message: "found no description".to_string(),
+                        message: "found no scope".to_string(),
                     });
                 }
                 Some(description) => {


### PR DESCRIPTION
# Why

Typo... this makes the user confusing because it emits errors like it has problems on description but in reality, it's on the scope.
