### PR TITLE
fix(cli)!: ignore empty scope by default

### DIFF
--- a/src/rule/scope_empty.rs
+++ b/src/rule/scope_empty.rs
@@ -16,7 +16,7 @@ pub struct ScopeEmpty {
 /// ScopeEmpty represents the scope-empty rule.
 impl Rule for ScopeEmpty {
     const NAME: &'static str = "scope-empty";
-    const LEVEL: Level = Level::Error;
+    const LEVEL: Level = Level::Ignore;
 
     fn message(&self, _message: &Message) -> String {
         "scope is empty".to_string()
@@ -79,10 +79,7 @@ mod tests {
         let violation = rule.validate(&message);
         assert!(violation.is_some());
         assert_eq!(violation.clone().unwrap().level, Level::Error);
-        assert_eq!(
-            violation.unwrap().message,
-            "scope is empty".to_string()
-        );
+        assert_eq!(violation.unwrap().message, "scope is empty".to_string());
     }
 
     #[test]
@@ -101,9 +98,6 @@ mod tests {
         let violation = rule.validate(&message);
         assert!(violation.is_some());
         assert_eq!(violation.clone().unwrap().level, Level::Error);
-        assert_eq!(
-            violation.unwrap().message,
-            "scope is empty".to_string()
-        );
+        assert_eq!(violation.unwrap().message, "scope is empty".to_string());
     }
 }

--- a/web/src/content/docs/rules/scope-empty.md
+++ b/web/src/content/docs/rules/scope-empty.md
@@ -3,7 +3,7 @@ title: Scope Empty
 description: Check if the scope exists
 ---
 
-* Default: `error`
+* Default: `ignore`
 
 ## ❌ Bad
 


### PR DESCRIPTION
# Why

Scope is optional in [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/):

```console
<type>[optional scope]: <description>

[optional body]

[optional footer(s)]
```

Thus, the scope should be completely emptyable. 
This is a part of #355.