### PR TITLE
fix(web): default config on default rules page

### DIFF
--- a/web/src/content/docs/config/default.md
+++ b/web/src/content/docs/config/default.md
@@ -13,10 +13,8 @@ You can also check the default values on the page of each rule.
 
 ```yaml
 rules:
-  description-empty: # Description must not be empty
+  description-empty: # Description shouldn't be empty
     level: warning
-  scope-empty: # Scope must not be empty
-    level: error
   subject-empty: # Subject line should exist
     level: error
   type-empty: # Type must not be empty

--- a/web/src/content/docs/rules/scope-empty.md
+++ b/web/src/content/docs/rules/scope-empty.md
@@ -3,7 +3,7 @@ title: Scope Empty
 description: Check if the scope exists
 ---
 
-* Default: `error`
+* Default: `ignore`
 
 ## ❌ Bad
 


### PR DESCRIPTION
# Why

As you can see here: 

https://github.com/KeisukeYamashita/commitlint-rs/blob/87ce94983778126ca1faabcaaaa680296f106e3c/src/rule.rs#L200

by default, the rule is ignored.
