### PR TITLE
feat(cli): add optional field for scope

### DIFF
--- a/web/src/content/docs/rules/scope.md
+++ b/web/src/content/docs/rules/scope.md
@@ -3,7 +3,9 @@ title: Scope
 description: Allowlist for scopes
 ---
 
-* Default: `ignore`
+* Default:
+  * Level: `ignore`
+  * Optional: `false`
 
 In this example, we assumed that you have a project with the following scopes:
 
@@ -41,6 +43,19 @@ rules:
       - api
       - web
 ```
+
+### Optional scopes `api` and `web`
+
+```yaml
+rules:
+  scope:
+    level: error
+    optional: true
+    options:
+      - api
+```
+
+With this configuration, `feat(api): xxx` and `feat: xxx` are valid commits.
 
 ### Disallow all scopes
 


### PR DESCRIPTION
Signed-off-by: KeisukeYamashita <19yamashita15@gmail.com># Why

Resolves: https://github.com/KeisukeYamashita/commitlint-rs/issues/355

In some cases,  scope can be optional, but users may want to apply an allow list if a value is provided.
Currently, the `scope-empty` and `scope` are exclusive, and this policy can be configured.
