### PR TITLE
fix(.github): docker image name without `-rs`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,7 +100,7 @@ jobs:
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: 1915keke/commitlint-rs
+          images: 1915keke/commitlint
           tags: |
             type=raw,value=latest
             type=semver,pattern={{version}}


### PR DESCRIPTION
# Why

Docker images are portable scripts, meaning users don't need to understand the underlying programming language.
Also, the CLI is also `commitlint` (without the `-rs`) so I think it's better to name the image without the `-rs`.