### PR TITLE
feat(cli): modify config short flag to `-c`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "commitlint-rs"
-version = "0.1.12"
+version = "0.2.0"
 dependencies = [
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.12"
+version = "0.2.0"
 authors = ["KeisukeYamashita <19yamashita15@gmail.com>"]
 license = "MIT OR Apache-2.0"
 documentation = "https://keisukeyamashita.github.io/commitlint-rs"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -8,7 +8,7 @@ use crate::rule::Rules;
 const DEFAULT_CONFIG_ROOT: &str = ".";
 
 /// Default commitlintrc configuration files
-/// If the user didn't specify a configuration file with -g or --config argument,
+/// If the user didn't specify a configuration file with -c or --config argument,
 /// we will try to find one of these files in the current directory.
 const DEFAULT_CONFIG_FILE: [&str; 4] = [
     ".commitlintrc",

--- a/web/src/content/docs/config/configuration.md
+++ b/web/src/content/docs/config/configuration.md
@@ -32,14 +32,14 @@ Note that it is searched in the order written above and the first one found is l
 
 ### Using the flag
 
-Configuration file can be specified by using the `--config` flag or the short `-g` flag.
+Configuration file can be specified by using the `--config` flag or the short `-c` flag.
 
 ```console
 # Using --config flag
 $ commitlint --config path/to/.commitlintrc.yml
 
-# Using -g flag
-$ commitlint -g path/to/.commitlintrc.yml
+# Using -c flag
+$ commitlint -c path/to/.commitlintrc.yml
 ```
 
 If you specify a file and the file is not found, Commitlint will throw an error.


### PR DESCRIPTION
# Why

I don't recall why I chose `-g` but `-c` is more understandable for `--config`.