### PR TITLE
fix(cli): dockerfile to adapt to workspaces

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -7,7 +7,8 @@ RUN  --mount=type=cache,target=/var/cache/apk,sharing=locked \
     && apk add --no-cache musl-dev
 
 COPY . .
-RUN cargo install --path .
+RUN cargo install --path ./cli && \
+    commitlint --version
 
 FROM alpine
 LABEL maintainer="KeisukeYamashita <19yamashita15@gmail.com>"


### PR DESCRIPTION
# Why

Since we now use Cargo workspaces, we have to update the Dockerfile too.
