### PR TITLE
fix(cli): package name and dockerfile path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,8 @@ jobs:
 
       - uses: docker/build-push-action@v6
         with:
-          context: ./cli
+          context: .
+          file: ./cli/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
-name = "cli"
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "commitlint-rs"
 version = "0.2.0"
 dependencies = [
  "clap",
@@ -167,12 +173,6 @@ dependencies = [
  "serde_yaml",
  "tokio",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "dyn-clone"
@@ -481,7 +481,7 @@ name = "schema"
 version = "0.2.0"
 dependencies = [
  "clap",
- "cli",
+ "commitlint-rs",
  "schemars",
  "serde",
  "serde_json",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "commitlint-rs"
 description = "CLI tool to lint commits by Conventional Commits"
 documentation.workspace = true
 authors.workspace = true

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -13,7 +13,7 @@ edition.workspace = true
 
 [dependencies]
 clap = { version = "4.5.21", features = ["derive"] }
-cli = { path = "../cli", features = ["schemars"] }
+cli = { path = "../cli", features = ["schemars"], package = "commitlint-rs" }
 schemars = { version = "0.8.21" }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"


### PR DESCRIPTION
# Why

Since we migrate to Cargo workspace, we have to change the context and the file path to the Dockerfile.
I also accidentally updated the package name so I've reverted it.