### PR TITLE
bump(cli): rust to `1.83`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM rust:1.81-alpine as builder
+FROM rust:1.83-alpine as builder
 WORKDIR /app
 
 RUN  --mount=type=cache,target=/var/cache/apk,sharing=locked \


### PR DESCRIPTION
# Why

To maintain this project, follow the latest release of Rust.
