### PR TITLE
fix(cli): transfer dockerfile using Git context

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,6 @@ jobs:
 
       - uses: docker/build-push-action@v6
         with:
-          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
# Why

Since I use the `context: .`, I can use the Git context.
Ref: https://github.com/docker/build-push-action/issues/989#issuecomment-1779108258
