### PR TITLE
fix(.github): default dir configuration from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,6 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
-defaults:
-  run:
-    working-directory: ./cli
-
 permissions:
   contents: write # To write to release
   id-token: write # To deploy to GitHub Pages


### PR DESCRIPTION
# Why

Solves: https://github.com/KeisukeYamashita/commitlint-rs/issues/398
As the title says, the release CI is failing.
Now we use Cargo workspace, I'll remove the default directory configuration which used to point to `cli/`.
