### PR TITLE
fix(.github): mismatch between CPU chip and binary name on macOS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,11 +26,11 @@ jobs:
             rust_target: x86_64-unknown-linux-gnu
             ext: ""
             args: ""
-          - os: macos-latest
+          - os: macos-13 (Intel x86)
             rust_target: x86_64-apple-darwin
             ext: ""
             args: ""
-          - os: macos-14 # beta (Apple Silicon)
+          - os: macos-latest (Apple Silicon)
             rust_target: aarch64-apple-darwin
             ext: ""
             args: ""


### PR DESCRIPTION
# Why

The `macos-latest` now points to Apple Silicon so the processor and the binary name (`x86_64`) mismatches.
To fix it, I pinned the `x86_64` binary name with the runner that runs the Intel chip.

## Ref

* [Choosing GitHub-hosted runners, GitHub Docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated macOS version specifications in the build workflow for improved clarity and targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->