### PR TITLE
fix: pre-commit misc fixes

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,9 @@
 - id: commitlint
   name: Assert Conventional Commit Messages
   description: 'Asserts that Conventional Commits have been used for all commit messages according to the rules for this repo.'
-  entry: commitlint --edit
+  entry: commitlint --edit .git/COMMIT_EDITMSG
   language: rust
-  stages: [prepare-commit-msg]
+  stages: [commit-msg]
   pass_filenames: false
   require_serial: true
   verbose: true


### PR DESCRIPTION
The patch fixes command line when used as pre-commit plugin and change the hook.

The --edit flag was asking for a argument which was not supplied by pre-commit.

When using prepare-commit-msg hook, it was impossible to use an editor for the commit message.

# Why

After "fixing" #428 by skipping compilation, I've found out that it was not working properly.
