### PR TITLE
fix(rule): report error message when type scope or body empty

### DIFF
--- a/cli/src/rule/body_max_length.rs
+++ b/cli/src/rule/body_max_length.rs
@@ -27,20 +27,12 @@ impl Rule for BodyMaxLength {
     }
 
     fn validate(&self, message: &Message) -> Option<Violation> {
-        match &message.body {
-            Some(body) => {
-                if body.len() >= self.length {
-                    return Some(Violation {
-                        level: self.level.unwrap_or(Self::LEVEL),
-                        message: self.message(message),
-                    });
-                }
-            }
-            None => {
+        if let Some(body) = &message.body {
+            if body.len() >= self.length {
                 return Some(Violation {
                     level: self.level.unwrap_or(Self::LEVEL),
                     message: self.message(message),
-                })
+                });
             }
         }
 

--- a/cli/src/rule/scope_max_length.rs
+++ b/cli/src/rule/scope_max_length.rs
@@ -27,20 +27,12 @@ impl Rule for ScopeMaxLength {
     }
 
     fn validate(&self, message: &Message) -> Option<Violation> {
-        match &message.scope {
-            Some(scope) => {
-                if scope.len() >= self.length {
-                    return Some(Violation {
-                        level: self.level.unwrap_or(Self::LEVEL),
-                        message: self.message(message),
-                    });
-                }
-            }
-            None => {
+        if let Some(scope) = &message.scope {
+            if scope.len() >= self.length {
                 return Some(Violation {
                     level: self.level.unwrap_or(Self::LEVEL),
                     message: self.message(message),
-                })
+                });
             }
         }
 

--- a/cli/src/rule/type_max_length.rs
+++ b/cli/src/rule/type_max_length.rs
@@ -27,20 +27,12 @@ impl Rule for TypeMaxLength {
     }
 
     fn validate(&self, message: &Message) -> Option<Violation> {
-        match &message.r#type {
-            Some(t) => {
-                if t.len() >= self.length {
-                    return Some(Violation {
-                        level: self.level.unwrap_or(Self::LEVEL),
-                        message: self.message(message),
-                    });
-                }
-            }
-            None => {
+        if let Some(t) = &message.r#type {
+            if t.len() >= self.length {
                 return Some(Violation {
                     level: self.level.unwrap_or(Self::LEVEL),
                     message: self.message(message),
-                })
+                });
             }
         }
 


### PR DESCRIPTION
# Why
I've tested the tool and plan to implement it in our company.
However there are some logical errors which blocked us to use it.

This commit to fix `(type|scope|body)_max-length` rules report incorrect message.

fix #440 
fix #441 
fix #442 

Signed-off-by: xieyongbin <xieyongbin@126.com>
