### PR TITLE
chore(cli): add no value test cases for max length linters

### DIFF
--- a/cli/src/rule/body_max_length.rs
+++ b/cli/src/rule/body_max_length.rs
@@ -85,6 +85,25 @@ Hey!"
     }
 
     #[test]
+    fn test_no_body() {
+        let rule = BodyMaxLength {
+            length: usize::MAX, // Long length for testing
+            ..Default::default()
+        };
+        let message = Message {
+            body: None,
+            description: Some("broadcast $destroy event on scope destruction".to_string()),
+            footers: None,
+            r#type: Some("feat".to_string()),
+            raw: "feat(scope): broadcast $destroy event on scope destruction".to_string(),
+            scope: Some("scope".to_string()),
+            subject: Some("feat(scope): broadcast $destroy event on scope destruction".to_string()),
+        };
+
+        assert!(rule.validate(&message).is_none());
+    }
+
+    #[test]
     fn test_short_body() {
         let rule = BodyMaxLength {
             length: 10, // Short length for testing

--- a/cli/src/rule/scope_max_length.rs
+++ b/cli/src/rule/scope_max_length.rs
@@ -82,6 +82,25 @@ mod tests {
     }
 
     #[test]
+    fn test_no_scope() {
+        let rule = ScopeMaxLength {
+            length: usize::MAX, // Long length for testing
+            ..Default::default()
+        };
+        let message = Message {
+            body: None,
+            description: Some("desc".to_string()),
+            footers: None,
+            r#type: Some("feat".to_string()),
+            raw: "feat(scope): desc".to_string(),
+            scope: None,
+            subject: Some("feat(scope): desc".to_string()),
+        };
+
+        assert!(rule.validate(&message).is_none());
+    }
+
+    #[test]
     fn test_short_scope() {
         let rule = ScopeMaxLength {
             length: 3, // Short length for testing

--- a/cli/src/rule/type_max_length.rs
+++ b/cli/src/rule/type_max_length.rs
@@ -82,6 +82,25 @@ mod tests {
     }
 
     #[test]
+    fn test_no_type() {
+        let rule = TypeMaxLength {
+            length: usize::MAX, // Long length for testing
+            ..Default::default()
+        };
+        let message = Message {
+            body: None,
+            description: Some("broadcast $destroy event on scope destruction".to_string()),
+            footers: None,
+            r#type: None,
+            raw: "feat(scope): broadcast $destroy event on scope destruction".to_string(),
+            scope: Some("scope".to_string()),
+            subject: Some("feat(scope): broadcast $destroy event on scope destruction".to_string()),
+        };
+
+        assert!(rule.validate(&message).is_none());
+    }
+
+    #[test]
     fn test_short_type() {
         let rule = TypeMaxLength {
             length: 3, // Short length for testing


### PR DESCRIPTION
# Why

Because there is a case where there are no values but the rules exist.
Max length rules should bypass `None` which means `0`.


## Ref

https://github.com/KeisukeYamashita/commitlint-rs/issues/440
https://github.com/KeisukeYamashita/commitlint-rs/issues/441
https://github.com/KeisukeYamashita/commitlint-rs/issues/442
