### PR TITLE
fix(.github): replace deprecated ubuntu runner with latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         config:
           # See details fore GitHub Actions runners
           # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             rust_target: x86_64-unknown-linux-gnu
             ext: ""
             args: ""


### PR DESCRIPTION
# Why

This runner is already deprecated and it will not spin up the CI.