### PR TITLE
feat: git worktree support

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -86,7 +86,8 @@ impl Args {
             return Ok(messages);
         }
 
-        let default_path = std::path::PathBuf::from(".git").join("COMMIT_EDITMSG");
+        // Use git::edit_msg_path to correctly resolve COMMIT_EDITMSG, supporting git worktrees.
+        let default_path = git::edit_msg_path(&self.cwd);
         let msg = std::fs::read_to_string(&default_path).expect(
             format!(
                 "Failed to read commit message from {}",


### PR DESCRIPTION
# Why

This PR fixes a panic when `commitlint-rs` is executed within a git worktree. It replaces the hardcoded `.git/COMMIT_EDITMSG` path with a dynamic resolution using `git rev-parse --git-path`.

### Why is this needed?

In a standard git repository, `.git` is a directory. However, in a git worktree, `.git` is a **file** containing a pointer to the main repository's `.git` directory. 

The previous implementation attempted to join `COMMIT_EDITMSG` to a `.git` path and read it as a file. When `.git` is a file (in a worktree), this results in an `Os { code: 20, kind: NotADirectory, message: "Not a directory" }` error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed commit message path resolution to correctly work with Git worktrees.

* **Tests**
  * Added unit tests for path resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->