### PR TITLE
bump(cli): bump Cargo version to v0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "commitlint-rs"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "futures",
@@ -478,7 +478,7 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schema"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "commitlint-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["cli", "schema"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 authors = ["KeisukeYamashita <19yamashita15@gmail.com>"]
 license = "MIT OR Apache-2.0"
 documentation = "https://keisukeyamashita.github.io/commitlint-rs"


### PR DESCRIPTION
## Summary
- Bump workspace version from v0.2.3 to v0.2.4

## Test plan
- [x] CI passes