### PR TITLE
feat(cli): remove async runtime, cache regexes, and tune release profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -57,32 +57,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
-
-[[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "bitflags"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -135,13 +111,11 @@ name = "commitlint-rs"
 version = "0.2.5"
 dependencies = [
  "clap",
- "futures",
  "regex",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
- "tokio",
 ]
 
 [[package]]
@@ -155,94 +129,6 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
-
-[[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "slab",
-]
 
 [[package]]
 name = "hashbrown"
@@ -279,66 +165,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "libc"
-version = "0.2.186"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "proc-macro2"
@@ -356,15 +186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -438,12 +259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,40 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,34 +340,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tokio"
-version = "1.52.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -608,33 +361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 members = ["cli", "schema"]
 resolver = "2"
 
+# Optimize release binaries for runtime speed, startup time, and size.
+[profile.release]
+codegen-units = 1
+lto = true
+strip = true
+
 [workspace.package]
 version = "0.2.5"
 authors = ["KeisukeYamashita <19yamashita15@gmail.com>"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,13 +19,11 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.6.1", features = ["derive", "env", "string"] }
-futures = "0.3.32"
 regex = "1.12.3"
 schemars = { version = "0.8.22", optional = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 serde_yaml = "0.9.34"
-tokio = { version = "1.49.0", features = ["full"] }
 
 [features]
 schemars = ["dep:schemars"]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -33,7 +33,7 @@ impl fmt::Display for Config {
 }
 
 /// Load configuration from the specified path.
-pub async fn load(path: Option<PathBuf>) -> Result<Config, String> {
+pub fn load(path: Option<PathBuf>) -> Result<Config, String> {
     let config_file = match &path {
         Some(p) => Some(p.clone()),
         None => find_config_file(PathBuf::from(DEFAULT_CONFIG_ROOT)),
@@ -41,7 +41,7 @@ pub async fn load(path: Option<PathBuf>) -> Result<Config, String> {
 
     match (config_file, path) {
         // If the file was specified and found, load it.
-        (Some(p), _) => load_config_file(p).await,
+        (Some(p), _) => load_config_file(p),
         // If the file was not specified and not found, return default config.
         (None, None) => Ok(Config::default()),
         // If the was explicitly specified but not found, return an error.
@@ -65,7 +65,7 @@ pub fn find_config_file(path: PathBuf) -> Option<PathBuf> {
 }
 
 /// Load config file from the specified path.
-pub async fn load_config_file(path: PathBuf) -> Result<Config, String> {
+pub fn load_config_file(path: PathBuf) -> Result<Config, String> {
     if !path.exists() {
         return Err(format!(
             "Configuration file not found in {}",
@@ -75,9 +75,9 @@ pub async fn load_config_file(path: PathBuf) -> Result<Config, String> {
 
     match path.extension() {
         Some(ext) => match ext.to_str() {
-            Some("json") => load_json_config_file(path).await,
-            Some("yaml") | Some("yml") => load_yaml_config_file(path).await,
-            _ => load_unknown_config_file(path).await,
+            Some("json") => load_json_config_file(path),
+            Some("yaml") | Some("yml") => load_yaml_config_file(path),
+            _ => load_unknown_config_file(path),
         },
         None => Err(format!(
             "Unsupported configuration file format: {}",
@@ -87,7 +87,7 @@ pub async fn load_config_file(path: PathBuf) -> Result<Config, String> {
 }
 
 /// Load JSON config file from the specified path.
-async fn load_json_config_file(path: PathBuf) -> Result<Config, String> {
+fn load_json_config_file(path: PathBuf) -> Result<Config, String> {
     let text = fs::read_to_string(path).unwrap();
 
     match serde_json::from_str::<Config>(&text) {
@@ -97,7 +97,7 @@ async fn load_json_config_file(path: PathBuf) -> Result<Config, String> {
 }
 
 /// Load YAML config file from the specified path.
-async fn load_yaml_config_file(path: PathBuf) -> Result<Config, String> {
+fn load_yaml_config_file(path: PathBuf) -> Result<Config, String> {
     let text = fs::read_to_string(path).unwrap();
 
     match serde_yaml::from_str::<Config>(&text) {
@@ -109,7 +109,7 @@ async fn load_yaml_config_file(path: PathBuf) -> Result<Config, String> {
 /// Try to load configuration file from the specified path.
 /// First try to load it as JSON, then as YAML.
 /// If both fail, return an error.
-async fn load_unknown_config_file(path: PathBuf) -> Result<Config, String> {
+fn load_unknown_config_file(path: PathBuf) -> Result<Config, String> {
     let text = fs::read_to_string(path.clone()).unwrap();
 
     if let Ok(config) = serde_json::from_str::<Config>(&text) {

--- a/cli/src/git.rs
+++ b/cli/src/git.rs
@@ -1,5 +1,6 @@
 use regex::Regex;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 use std::{collections::HashMap, process::Command};
 /// ReadCommitMessageOptions represents the options for reading commit messages.
 /// Transparently, it is defined to be similar to the behavior of the git log command.
@@ -77,8 +78,9 @@ pub fn read(options: ReadCommitMessageOptions) -> Vec<String> {
 }
 
 fn extract_commit_messages(input: &str) -> Vec<String> {
-    let commit_delimiter = Regex::new(r"(?m)^commit [0-9a-f]{40}$").unwrap();
-    let commits: Vec<&str> = commit_delimiter.split(input).collect();
+    static COMMIT_DELIMITER: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?m)^commit [0-9a-f]{40}$").unwrap());
+    let commits: Vec<&str> = COMMIT_DELIMITER.split(input).collect();
 
     let mut messages: Vec<String> = Vec::new();
 
@@ -148,11 +150,11 @@ pub fn parse_commit_message(
 /// does not have any rules for it.
 /// See: https://commitlint.js.org/reference/rules.html
 pub fn parse_subject(subject: &str) -> (Option<String>, Option<String>, Option<String>) {
-    let re = regex::Regex::new(
-        r"^(?P<type>\w+)(?:\((?P<scope>[^\)]+)\))?(?:!)?\:\s?(?P<description>.*)$",
-    )
-    .unwrap();
-    if let Some(captures) = re.captures(subject) {
+    static SUBJECT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"^(?P<type>\w+)(?:\((?P<scope>[^\)]+)\))?(?:!)?\:\s?(?P<description>.*)$")
+            .unwrap()
+    });
+    if let Some(captures) = SUBJECT_REGEX.captures(subject) {
         let r#type = captures.name("type").map(|m| m.as_str().to_string());
         let scope = captures.name("scope").map(|m| m.as_str().to_string());
         let description = captures.name("description").map(|m| m.as_str().to_string());

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -11,11 +11,10 @@ use message::validate;
 
 use std::process::exit;
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let args = Args::parse();
 
-    let config = match config::load(args.config.clone()).await {
+    let config = match config::load(args.config.clone()) {
         Ok(c) => c,
         Err(err) => {
             eprintln!("Failed to load config: {}", err);
@@ -35,15 +34,10 @@ async fn main() {
         }
     };
 
-    let threads = messages
-        .into_iter()
-        .map(|message| {
-            let config = config.clone();
-            tokio::spawn(async move { validate(&message, &config).await })
-        })
+    let results = messages
+        .iter()
+        .map(|message| validate(message, &config))
         .collect::<Vec<_>>();
-
-    let results = futures::future::join_all(threads).await;
 
     let mut has_error: bool = false;
     for result in &results {
@@ -51,7 +45,7 @@ async fn main() {
             eprintln!("{}", err);
         }
 
-        if let Ok(Ok(h)) = result {
+        if let Ok(h) = result {
             if !h.violations.is_empty() {
                 for violation in &h.violations {
                     match violation.level {

--- a/cli/src/message.rs
+++ b/cli/src/message.rs
@@ -59,7 +59,7 @@ impl Message {
 }
 
 /// validate the raw commit message.
-pub async fn validate(msg: &Message, config: &Config) -> Result<LintResult, Error> {
+pub fn validate(msg: &Message, config: &Config) -> Result<LintResult, Error> {
     let violations = config.rules.validate(msg);
     Ok(LintResult { violations })
 }


### PR DESCRIPTION
# Why

`commitlint` is typically invoked once per commit (git hooks, CI), so process startup dominates its total runtime. Profiling showed most of that time was spent on overhead unrelated to linting:

- `#[tokio::main]` spins up a multi-threaded runtime (one worker per core) even though the entire workload is a handful of regex matches on a short string — there is no I/O to await.
- `parse_subject` compiled its regex with `Regex::new` on every call.
- The workspace had no `[profile.release]` tuning.

# What

All changes are internal — CLI behavior, output, and exit codes are unchanged.

1. **Remove `tokio` and `futures`, run validation synchronously** (`main.rs`, `config.rs`, `message.rs`). The `async` functions never awaited anything; validation is now a plain loop, which also removes the per-message `config.clone()`. Drops 272 lines of dependencies from `Cargo.lock`.
2. **Cache regexes with `std::sync::LazyLock`** (`git.rs`): the subject parser and commit delimiter regexes are compiled once instead of per message.
3. **Tune the release profile** (root `Cargo.toml`): `lto = true`, `codegen-units = 1`, `strip = true`. (`panic = "abort"` was deliberately left out since it would change the exit code on panic.)

# Benchmarks

Measured with `hyperfine -N` (no shell), 1,200–1,900 runs per case, Apple Silicon, Rust 1.95:

| Scenario | Before (median) | After (median) | Speedup | CPU time (user+sys) |
|---|---|---|---|---|
| stdin lint | 2.20 ms | 1.65 ms | **1.34×** | 2.67 ms → 1.33 ms (**−50%**) |
| `-e <file>` (git hook) | 2.22 ms | 1.67 ms | **1.33×** | 2.64 ms → 1.33 ms |
| YAML config + format rules | 2.38 ms | 1.92 ms | **1.24×** | 2.84 ms → 1.58 ms |
| `--from`/`--to` range | 15.6 ms | 15.1 ms | 1.03× (dominated by the `git log` subprocess) |

- Binary size: **3.68 MB → 2.12 MB (−42%)**
- Peak RSS: 4.69 MB → 3.49 MB (−26%)
- Instructions retired: 27.5 M → 21.7 M

# Verification

- Output and exit codes are **byte-identical** between the old and new binaries across 14 scenarios: `--help`, `--version`, valid/invalid/empty stdin, `-e` with valid/invalid files, `--print-config`, strict config, missing config file, invalid regex in config, multi-line messages with footers, and `--from`/`--to` (run under a pty so stdin detection behaves as in a terminal).
- All 65 unit tests pass; `cargo fmt --check` and `clippy` are clean (only the pre-existing `Rule::NAME` dead-code warning remains).
- The `schema` crate still builds and generates the JSON schema.

# Notes

- **Library API**: `config::load`, `config::load_config_file`, and `message::validate` changed from `async fn` to `fn`. The CLI is unaffected, but downstream users of the `commitlint-rs` lib crate would see a signature change.
- **Pre-existing bug (intentionally not fixed here, to keep behavior identical)**: `--from`/`--to` splits `git log --pretty=%B` output on `commit <sha>` lines, but `%B` never emits those lines, so the whole range is parsed as a single message and only the first commit's subject is effectively linted (`cli/src/git.rs`). Happy to fix that in a follow-up PR.
