### PR TITLE
chore(.github): speed up CI and fix release workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,18 +1,18 @@
 name: CI
 on:
-  - pull_request
+  pull_request:
+  push:
+    branches:
+      - main # To save caches that pull requests can restore
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_PROFILE_DEV_DEBUG: "0" # Faster builds, smaller caches
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
-        with:
-          components: rustfmt, clippy
-
-      - run: cargo build
-
   e2e:
     runs-on: ubuntu-latest
     strategy:
@@ -22,16 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          shared-key: release
       - run: cargo build --release
       - run: |
           sudo chmod +x target/release/commitlint
@@ -46,24 +39,13 @@ jobs:
       steps:
         - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         - run: cargo run --package schema -- --path schema.json
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
-        with:
-          components: rustfmt, clippy
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
-
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,8 +3,12 @@ on:
   pull_request:
     types:
       - opened
-      - edited
+      - edited # Only the title job needs this, other jobs skip it
       - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read # To checkout
@@ -13,6 +17,7 @@ permissions:
 jobs:
   actionlint:
     name: actionlint
+    if: github.event.action != 'edited'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,6 +27,7 @@ jobs:
           reporter: github-pr-review
 
   alex:
+    if: github.event.action != 'edited'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,19 +37,20 @@ jobs:
           reporter: github-pr-review
 
   assign-author:
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@3e19bfc990cb1cf0589dce95e9f75289bb1e22de # v3.0.3
 
   clippy:
+    if: github.event.action != 'edited'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2 # nightly
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          components: rustfmt, clippy
-
-      - run: cargo clippy
+          components: clippy
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - uses: sksat/action-clippy@87e08e0c289f2654fe702b0aaf88c2f1027a3e57 # v1.1.1
         with:
@@ -51,6 +58,7 @@ jobs:
 
   markdown:
     name: markdown
+    if: github.event.action != 'edited'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,6 +70,7 @@ jobs:
 
   misspell:
     name: misspell
+    if: github.event.action != 'edited'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -143,9 +143,12 @@ jobs:
 
       - run: |
           cd /tmp/digests
-          docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '1915keke/commitlint@sha256:%s ' *)
+          mapfile -t tag_args < <(jq -r '.tags[] | "-t", .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          refs=()
+          for digest in *; do
+            refs+=("1915keke/commitlint@sha256:${digest}")
+          done
+          docker buildx imagetools create "${tag_args[@]}" "${refs[@]}"
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,31 +25,28 @@ jobs:
           - os: ubuntu-latest
             rust_target: x86_64-unknown-linux-gnu
             ext: ""
-            args: ""
-          - os: macos-13 # (Intel x86)
+          - os: macos-latest # Cross compile from Apple Silicon
             rust_target: x86_64-apple-darwin
             ext: ""
-            args: ""
           - os: macos-latest # (Apple Silicon)
             rust_target: aarch64-apple-darwin
             ext: ""
-            args: ""
           - os: windows-latest
             rust_target: x86_64-pc-windows-msvc
             ext: ".exe"
-            args: ""
-          - os: windows-latest
+          - os: windows-latest # Cross compile from x64
             rust_target: aarch64-pc-windows-msvc
             ext: ".exe"
-            args: "--no-default-features --features native-tls-vendored"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.config.rust_target }}
 
-      - run: cargo build --package commitlint-rs --release
+      - run: cargo build --package commitlint-rs --release --target ${{ matrix.config.rust_target }}
 
-      - run: tar czvf commitlint-${{ github.ref_name }}-${{ matrix.config.rust_target }}.tar.gz -C target/release commitlint${{ matrix.config.ext }}
+      - run: tar czvf commitlint-${{ github.ref_name }}-${{ matrix.config.rust_target }}.tar.gz -C target/${{ matrix.config.rust_target }}/release commitlint${{ matrix.config.ext }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -63,25 +60,69 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo publish --package commitlint-rs
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+  # Build each platform natively (no QEMU emulation) and push by digest,
+  # then the docker-merge job assembles the multi-arch manifest.
   docker:
+    runs-on: ${{ matrix.os }}
+    environment: docker
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux/amd64
+          - os: ubuntu-24.04-arm
+            platform: linux/arm64
+    steps:
+      - id: platform
+        run: echo "pair=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=1915keke/commitlint,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+      - run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ steps.platform.outputs.pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-merge:
     runs-on: ubuntu-latest
     environment: docker
+    needs:
+      - docker
     steps:
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
@@ -100,31 +141,29 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - run: |
+          cd /tmp/digests
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '1915keke/commitlint@sha256:%s ' *)
 
   publish:
     runs-on: ubuntu-latest
     needs:
       - build
       - crate
-      - docker
+      - docker-merge
       - schema
       - web
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: commitlint
-          pattern: commitlint-*
+          pattern: "{commitlint-*,schema.json}"
           merge-multiple: true
       - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
-          artifacts: commitlint/commitlint-*.tar.gz,schema.json
+          artifacts: commitlint/commitlint-*.tar.gz,commitlint/schema.json
           generateReleaseNotes: true
 
   schema:
@@ -132,6 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - run: cargo run --package schema -- --path schema.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
# Why

CI run history showed that caching was effectively broken on pull requests and that the release workflow was both slow and unable to complete. This PR tunes the workflows based on that data.

## Findings from run history

- **PR CI (~60s per PR)**: the critical path is `cargo build --release` in the `e2e` matrix (~35s × 2). Cache restores measured 0–1s, i.e. always empty, because:
  - CI only runs on `pull_request`, so no cache is ever saved on `main` — and GitHub's cache scoping prevents PRs from sharing caches with each other.
  - `test` (debug/nightly) and `e2e` (release/stable) raced on the same cache key, so the release artifacts were never cached.
- **Lint**: editing a PR title (`edited` event) re-ran every job, including a full clippy compile. Clippy also ran twice (bare `cargo clippy` + `sksat/action-clippy`).
- **Release (last two runs cancelled)**:
  - The `docker` job took **17.6 minutes** building linux/arm64 under QEMU emulation.
  - `macos-13` runners are retired, so that job queued forever and `publish` never ran.
  - The Windows aarch64 job never passed `--target` (nor the matrix `args`, which referenced a nonexistent `native-tls-vendored` feature), so it shipped an x86_64 binary labelled as aarch64.
  - The `publish` job's `pattern: commitlint-*` no longer downloads the `schema.json` artifact, which would silently drop it from the next release.

## Changes

### `ci.yaml`
- Add a `push: main` trigger so merges warm the cache that all PRs can restore.
- Replace hand-rolled `actions/cache` with `Swatinem/rust-cache@v2` in every Rust job (the two `e2e` matrix legs share one cache via `shared-key: release`).
- Remove the redundant `build` job (`cargo test` performs the same compile).
- Switch nightly → stable (preinstalled on runners: ~1s vs ~10s install; consistent with e2e/release/Docker) and drop unused `rustfmt`/`clippy` components.
- Add `concurrency` to cancel superseded PR runs, and `CARGO_PROFILE_DEV_DEBUG=0` for faster builds and smaller caches.

### `lint.yaml`
- Skip everything except the `title` job on `edited` events; run `assign-author` only on `opened`.
- clippy: add rust-cache, remove the duplicated bare `cargo clippy` step, switch to stable.
- Add `concurrency` with cancel-in-progress.

### `release.yaml`
- Split the Docker build into native runners — linux/amd64 on `ubuntu-latest`, linux/arm64 on `ubuntu-24.04-arm` (free for public repos) — pushing by digest, with a `docker-merge` job assembling the multi-arch manifest. No more QEMU: ~17.6 min → ~3 min expected.
- Replace retired `macos-13` with an x86_64 cross-compile from `macos-latest`.
- Build every target with an explicit `--target`, fixing the Windows aarch64 binary, and drop the dead `args` matrix field.
- Fix `schema.json` being dropped from release assets.
- Add rust-cache to the `crate` and `schema` jobs.

## Notes

- The required status checks `e2e (cli)` / `e2e (default)` keep their names, so no ruleset change is needed.
- Cache benefits kick in after this lands on `main` and CI runs there once.
- `paths-ignore` for web-only PRs was deliberately not added: skipping the workflow would leave the required e2e checks unreported and block merges.
- All workflows pass `actionlint`.